### PR TITLE
Update NASA ODSI links to new official URL

### DIFF
--- a/_data/aboutme.yml
+++ b/_data/aboutme.yml
@@ -17,7 +17,7 @@ Work_Location : >
 
 # Short bio shown under the hero name (1-3 sentences). Plain text only.
 Bio_Short : >
- I am currently a Computer Scientist at [NASA ODSI](https://www.earthdata.nasa.gov/esds/impact) (Office of Data Science and Informatics, formerly NASA IMPACT), where my
+ I am currently a Computer Scientist at [NASA ODSI](https://www.nasa.gov/marshall/marshall-space-flight-missions/office-of-data-science-and-informatics-odsi/) (Office of Data Science and Informatics, formerly NASA IMPACT), where my
  research focuses on building and scaling AI Foundation Models for Science. I completed my MS by Research 
  under the supervision of [Dr. Amit K. Roy Chowdhury](https://vcg.ece.ucr.edu/amit)  
  at University of California-Riverside, where my thesis explored 3D human pose estimation for the 

--- a/_data/experience.yml
+++ b/_data/experience.yml
@@ -1,5 +1,5 @@
 - company: NASA - ODSI (Office of Data Science) / UAH
-  url: https://impact.earthdata.nasa.gov/
+  url: https://www.nasa.gov/marshall/marshall-space-flight-missions/office-of-data-science-and-informatics-odsi/
   title: Computer Scientist II
   date: May 2024 - Present
   location: Huntsville, AL, USA

--- a/_data/news.yml
+++ b/_data/news.yml
@@ -39,7 +39,7 @@ news:
 
   - date: May'24
     description: >
-      Joined [NASA ODSI](https://www.earthdata.nasa.gov/esds/impact) as a Computer Scientist II.
+      Joined [NASA ODSI](https://www.nasa.gov/marshall/marshall-space-flight-missions/office-of-data-science-and-informatics-odsi/) as a Computer Scientist II.
 
   - date: Jan'24
     description: >


### PR DESCRIPTION
Updates the NASA ODSI link across the site to the new official URL: https://www.nasa.gov/marshall/marshall-space-flight-missions/office-of-data-science-and-informatics-odsi/.

Updated in `_data/aboutme.yml`, `_data/news.yml`, and `_data/experience.yml`.

Closes #29.

Generated with [Claude Code](https://claude.ai/code)